### PR TITLE
Move zeroing layers to inside an operator

### DIFF
--- a/joey/layers.py
+++ b/joey/layers.py
@@ -483,8 +483,7 @@ class MaxPooling(Pooling):
         a = self._backward_tmp_constants[0]
         b = self._backward_tmp_constants[1]
 
-        return ([Eq(next_layer.result_gradients, 0),
-                 Eq(a, index // 2),
+        return ([Eq(a, index // 2),
                  Eq(b, index % 2),
                  Inc(next_layer.result_gradients[dims[0],
                                                  dims[1],


### PR DESCRIPTION
Currently, Joey zeroes layer Functions in Python. This PR moves this operation (along with dividing the gradients by a batch size in a backward pass) to inside a forward/backward pass operator.